### PR TITLE
Fix command palette crash and self-hosted instance URL support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## Documentation
+
+When making changes to source files or configuration (e.g. `src/extension.ts`, `package.json`), update `README.md` as needed to keep it accurate — including setting names, defaults, usage instructions, and example URLs.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 ## Features
 
 - **Quick Access:** Open any file in Gitlab directly from VS Code.
-- **Customizable Settings:** Configure the Gitlab base path to match your project's structure.
-- **Seamless Integration:** Integrates with the VS Code explorer context menu for easy access.
+- **Customizable Settings:** Configure the GitLab instance URL to point at gitlab.com or any self-hosted instance.
+- **Seamless Integration:** Integrates with the VS Code explorer context menu and command palette for easy access.
 
 ## Installation
 
@@ -26,45 +26,45 @@
    - Search for **Open in Gitlab** to find the extension's settings.
    - Set the following configuration options:
 
-     - **Base Path (`openInGitlab.basePath`):**
+     - **Instance URL (`openInGitlab.instanceUrl`):**
 
-       - The base path used in the Gitlab URL (e.g., "code.company.com/path").
+       - The full URL of your GitLab instance (e.g., `https://gitlab.com` or `https://gitlab.mycompany.com`). Defaults to `https://gitlab.com`.
 
 2. **Using the Extension:**
 
-   - In the VS Code explorer, right-click on a file.
-   - Select **Open in Gitlab** from the context menu.
-   - The corresponding file will open in your default web browser via Gitlab.
+   - In the VS Code explorer, right-click on a file and select **Open in Gitlab** from the context menu, **or**
+   - Open the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run **Open in Gitlab** to open the currently active file.
+   - The corresponding file will open in your default web browser.
 
 ## Configuration Options
 
 The extension can be customized through the following settings:
 
-### `openInGitlab.basePath`
+### `openInGitlab.instanceUrl`
 
 - **Type:** `string`
-- **Default:** "your-base-path"
-- **Description:** The base path in the Gitlab URL after the domain. This may include paths specific to your organization's Gitlab setup.
+- **Default:** `"https://gitlab.com"`
+- **Description:** The full URL of your GitLab instance. Use the default for gitlab.com or set this to your self-hosted instance (e.g. `https://gitlab.mycompany.com`).
 
 ## Example Configuration
 
-You should configure the extension settings as follows:
+For a self-hosted instance, set:
 
-- **Base Path:**
+```json
+"openInGitlab.instanceUrl": "https://gitlab.mycompany.com"
+```
 
-  "https://code.company.com/path"
-
-With these settings, the extension constructs the Gitlab URL as:
+With that setting, the extension constructs URLs in the form:
 
 ```
-https://code.company.com/path/<workspace-folder>/-/blob/<headBranchName>/<relativeFilePath>
+https://gitlab.mycompany.com/<workspace-folder>/-/blob/<branch>/<relativeFilePath>
 ```
 
 ## Troubleshooting
 
 - **Incorrect URL Structure:**
 
-  - Double-check your `basePath` settings to ensure they match your organization's Gitlab URL structure.
+  - Double-check your `instanceUrl` setting and ensure it includes the protocol (`https://`) and no trailing slash.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
       "type": "object",
       "title": "Open in Gitlab Configuration",
       "properties": {
-        "openInGitlab.basePath": {
+        "openInGitlab.instanceUrl": {
           "type": "string",
-          "default": "your-base-path",
-          "description": "The base path used in the Gitlab URL."
+          "default": "https://gitlab.com",
+          "description": "The full URL of your GitLab instance (e.g. https://gitlab.com or https://gitlab.mycompany.com)."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,16 @@ export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
     "openInGitlab.open",
     (uri: vscode.Uri) => {
+      // Fall back to the active text editor when invoked from the command palette
+      if (!uri) {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+          vscode.window.showErrorMessage("No file is currently open.");
+          return;
+        }
+        uri = editor.document.uri;
+      }
+
       const filePath = uri.fsPath;
       const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
 
@@ -15,26 +25,24 @@ export function activate(context: vscode.ExtensionContext) {
 
       // Read settings from configuration
       const config = vscode.workspace.getConfiguration("openInGitlab");
-      const basePath = config.get<string>("basePath", "your-base-path");
+      const instanceUrl = config
+        .get<string>("instanceUrl", "https://gitlab.com")!
+        .replace(/\/$/, "");
 
       // Extract repository name from workspace folder
       const repoName = workspaceFolder.name;
       const branch = getRepoHeadName(uri);
 
-      // Get the file path relative to the repository root
-      const relativeFilePath = path.relative(
-        workspaceFolder.uri.fsPath,
-        filePath
-      );
+      // Get the file path relative to the repository root, normalizing to forward slashes
+      const relativeFilePath = path
+        .relative(workspaceFolder.uri.fsPath, filePath)
+        .split(path.sep)
+        .join("/");
 
-      // Construct the Gitlab URL
-      const gitlabUrl = path.join(
-        basePath,
-        repoName,
-        "/-/blob/",
-        branch,
-        relativeFilePath
-      );
+      // Construct the GitLab URL, filtering empty segments to avoid double slashes
+      const gitlabUrl = [instanceUrl, repoName, "-/blob", branch, relativeFilePath]
+        .filter(Boolean)
+        .join("/");
 
       console.log("GitLab URL:", gitlabUrl);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from "vscode";
 import * as path from "path";
 
 export function activate(context: vscode.ExtensionContext) {
+  warnIfLegacyBasePath();
+
   let disposable = vscode.commands.registerCommand(
     "openInGitlab.open",
     (uri: vscode.Uri) => {
@@ -50,6 +52,31 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
   context.subscriptions.push(disposable);
+}
+
+function warnIfLegacyBasePath() {
+  const config = vscode.workspace.getConfiguration("openInGitlab");
+  const inspected = config.inspect<string>("basePath");
+  const isSet =
+    inspected?.globalValue !== undefined ||
+    inspected?.workspaceValue !== undefined ||
+    inspected?.workspaceFolderValue !== undefined;
+
+  if (isSet) {
+    vscode.window
+      .showWarningMessage(
+        "Open in GitLab: The 'openInGitlab.basePath' setting has been replaced by 'openInGitlab.instanceUrl'. Please update your settings.",
+        "Open Settings"
+      )
+      .then((selection) => {
+        if (selection === "Open Settings") {
+          vscode.commands.executeCommand(
+            "workbench.action.openSettings",
+            "openInGitlab.instanceUrl"
+          );
+        }
+      });
+  }
 }
 
 function getRepoHeadName(workspaceUri: vscode.Uri): string {


### PR DESCRIPTION
Issue 1: Guard against undefined uri when the command is invoked from
the command palette (where no explorer context is provided). Falls back
to the active text editor's document URI, and returns early with an
error message if neither source yields a valid URI.

Issue 2: Replace the vague `basePath` setting (defaulting to a
placeholder) with an `instanceUrl` setting that defaults to
https://gitlab.com. Trailing slashes are stripped from the instance URL
and path segments are joined with "/" (filtering empty parts to avoid
double slashes), replacing the previous path.join() call that could
produce OS-specific backslash separators on Windows.

https://claude.ai/code/session_013hnJnfB2Pm9BnrAu85L63H