### PR TITLE
Fix HEAD lookup against the VS Code Git API

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,8 +52,17 @@ function getRepoHeadName(workspaceUri: vscode.Uri): string {
   }
 
   const api = gitExtension.getAPI(1);
-  const { repositories } = api;
-  const headName = repositories[0].repository.HEAD.name;
+  const repository =
+    api.getRepository(workspaceUri) ?? api.repositories[0];
+
+  if (!repository) {
+    vscode.window.showErrorMessage(
+      "Open in Gitlab: No git repository found for this file."
+    );
+    return "";
+  }
+
+  const headName = repository.state.HEAD?.name;
 
   if (!headName) {
     vscode.window.showErrorMessage(


### PR DESCRIPTION
## Summary
- `getRepoHeadName` was reading `repositories[0].repository.HEAD.name`, but the VS Code Git API has no `.repository` property on `Repository` — HEAD lives at `repository.state.HEAD`. Every right-click triggered `Cannot read properties of undefined (reading 'HEAD')`.
- Switched to `api.getRepository(uri)` so the correct repo is picked in multi-root workspaces, with a fallback to `api.repositories[0]`, and read `state.HEAD?.name` with a friendly error if no repo is found.

## Test plan
- [ ] Reload the extension, right-click a file in an initialized git repo, confirm the GitLab URL opens with the current branch.
- [ ] Right-click a file in a workspace folder that is not a git repo and confirm the "No git repository found" message appears instead of a stack trace.
- [ ] Multi-root workspace: confirm the URL uses the branch of the repo containing the right-clicked file, not always the first one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)